### PR TITLE
修复：typescript 推理类型优化 & createPromiseEvent 返回闭包错误

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+## 1.1.0 (2025-03-24)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@huolala-tech/preload-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@huolala-tech/preload-js",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.13.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huolala-tech/preload-js",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "页面数据预请求与缓存",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
fix:
1. function preload and usePreload return type changes from Promise<R> to Promise<Awaited<R>>.
2. createPromiseEvent function return promise status not change correctly.